### PR TITLE
fixes for travis

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "gulp-jscs": "^3.0.2",
     "gulp-jshint": "^2.0.0",
     "gulp-mocha": "^2.2.0",
-    "jshint": "^2.9.1-rc2",
+    "jshint": "^2.x",
     "lodash": "^3.10.1",
     "mocha": "^2.3.4",
     "tmp": "0.0.28"

--- a/test/jsoner.append.spec.js
+++ b/test/jsoner.append.spec.js
@@ -24,13 +24,13 @@ describe('jsoner', function() {
         it('fails to append to a file in an inexistent file', function() {
             expect(function() {
                 jsoner.appendFileSync(tmpFilename, {});
-            }).to.throw('ENOENT: no such file or directory');
+            }).to.throw(/ENOENT. no such file or directory/);
         });
 
         it('fails to append to a file in an inexistent path', function() {
             expect(function() {
                 jsoner.appendFileSync('/no/mans/land/foo.juttle', {});
-            }).to.throw('ENOENT: no such file or directory');
+            }).to.throw(/ENOENT. no such file or directory/);
         });
 
         it('fails to append an object to an incomplete JSON array', function() {


### PR DESCRIPTION
fix test expectation for slightly different error message between
0.10.x and 4.x+ node versions

remove the jshint devDependencies which brings up a bunch of issues
covered here: https://github.com/spalger/gulp-jshint/issues/133
